### PR TITLE
added a directory separator after the working directory to fix a bug …

### DIFF
--- a/img.ado
+++ b/img.ado
@@ -146,7 +146,7 @@ version 11
 		}
 		
 		// try to navigate to Weaver-figure, to check if it already exists
-		local d : pwd
+		local d `"`c(pwd)'`c(dirsep)'"'
 		capture cd "`WF'"
 		
 		if _rc != 0 {


### PR DESCRIPTION
…using the root directory of a harddrive on Windows

I have a network drive mounted at H: on windows and use that as a working directory. When I run img, then it stores my current working directory as "H:". After checking the existence of the Weaver-figure directory, img tries to cd back to the working directory. The problem is that

cd H:

does not change the working directory. It changes to the H drive keeping what ever directory you happen to be working on on that drive at the moment.

This relates to the "separate current directory for each drive" feature of Windows. See

http://superuser.com/questions/135214/using-cd-command-in-windows-command-line-cant-navigate-to-d
